### PR TITLE
Refactor NODE_PATH generation into a shared script

### DIFF
--- a/shared-build-scripts/build-node-path.sh
+++ b/shared-build-scripts/build-node-path.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -eo pipefail
+
+ROOT_DIR="$1"
+MODULE_TARGET_DIR="$2"
+BASE_TARGET_DIR="$3"
+TS_DEPS_FILE="$4"
+# FFI_NAPI_DIR is optional
+FFI_NAPI_DIR="${5:-}" # Default to empty if not provided
+
+{
+  echo "$MODULE_TARGET_DIR"
+  echo "$BASE_TARGET_DIR"
+  if [[ -f "$TS_DEPS_FILE" && -s "$TS_DEPS_FILE" ]]; then
+    # Prepend base_target_dir to each dependency path from the tsdeps file
+    # Note: paths in tsdeps are relative to $ROOT_DIR/target/
+    sed "s|^|$BASE_TARGET_DIR/|" "$TS_DEPS_FILE"
+  fi
+  if [[ -n "$FFI_NAPI_DIR" ]]; then
+    echo "$FFI_NAPI_DIR"
+  fi
+} | sort -u | paste -sd ":" -


### PR DESCRIPTION
A new script, shared-build-scripts/build-node-path.sh, has been created to centralize the logic for constructing the NODE_PATH environment variable for TypeScript test scripts. This script takes relevant paths (root, module target, base target, tsdeps file, and an optional ffi-napi path) as arguments and produces a colon-separated NODE_PATH string.

This change is analogous to how CLASSPATH is handled for Java builds.

Note: I was unable to modify the consuming test scripts (typescripttests/applications/mmmm/.tests.sh and
typescripttests/components/explanation/.tests.sh) to use this new shared script due to persistent issues that prevented file modifications. These files remain unchanged.